### PR TITLE
Migrating from master-slave language

### DIFF
--- a/src/tyk-gateway/_vendor-20180901134157/github.com/TykTechnologies/redigocluster/rediscluster/rediscluster.go
+++ b/src/tyk-gateway/_vendor-20180901134157/github.com/TykTechnologies/redigocluster/rediscluster/rediscluster.go
@@ -177,7 +177,7 @@ func (self *RedisCluster) KeyForRequest(cmd string, args ...interface{}) string 
 	if cmd == "info" ||
 		cmd == "multi" ||
 		cmd == "exec" ||
-		cmd == "slaveof" ||
+		cmd == "subordinateof" ||
 		cmd == "config" ||
 		cmd == "shutdown" {
 		return ""

--- a/src/tyk-gateway/_vendor-20180901134157/github.com/golang/protobuf/proto/discard.go
+++ b/src/tyk-gateway/_vendor-20180901134157/github.com/golang/protobuf/proto/discard.go
@@ -60,7 +60,7 @@ func DiscardUnknown(m Message) {
 		return
 	}
 	// TODO: Dynamically populate a InternalMessageInfo for legacy messages,
-	// but the master branch has no implementation for InternalMessageInfo,
+	// but the main branch has no implementation for InternalMessageInfo,
 	// so it would be more work to replicate that approach.
 	discardLegacy(m)
 }

--- a/src/tyk-gateway/_vendor-20180901134157/github.com/lonelycode/redigocluster/rediscluster/rediscluster.go
+++ b/src/tyk-gateway/_vendor-20180901134157/github.com/lonelycode/redigocluster/rediscluster/rediscluster.go
@@ -177,7 +177,7 @@ func (self *RedisCluster) KeyForRequest(cmd string, args ...interface{}) string 
 	if cmd == "info" ||
 		cmd == "multi" ||
 		cmd == "exec" ||
-		cmd == "slaveof" ||
+		cmd == "subordinateof" ||
 		cmd == "config" ||
 		cmd == "shutdown" {
 		return ""

--- a/src/tyk-gateway/_vendor-20180901134157/github.com/mattn/go-isatty/isatty_windows.go
+++ b/src/tyk-gateway/_vendor-20180901134157/github.com/mattn/go-isatty/isatty_windows.go
@@ -38,7 +38,7 @@ func IsTerminal(fd uintptr) bool {
 
 // Check pipe name is used for cygwin/msys2 pty.
 // Cygwin/MSYS2 PTY has a name like:
-//   \{cygwin,msys}-XXXXXXXXXXXXXXXX-ptyN-{from,to}-master
+//   \{cygwin,msys}-XXXXXXXXXXXXXXXX-ptyN-{from,to}-main
 func isCygwinPipeName(name string) bool {
 	token := strings.Split(name, "-")
 	if len(token) < 5 {
@@ -61,7 +61,7 @@ func isCygwinPipeName(name string) bool {
 		return false
 	}
 
-	if token[4] != "master" {
+	if token[4] != "main" {
 		return false
 	}
 

--- a/src/tyk-gateway/_vendor-20180901134157/github.com/miekg/dns/xfr.go
+++ b/src/tyk-gateway/_vendor-20180901134157/github.com/miekg/dns/xfr.go
@@ -29,10 +29,10 @@ type Transfer struct {
 // in the Transfer.Conn:
 //
 //	d := net.Dialer{LocalAddr: transfer_source}
-//	con, err := d.Dial("tcp", master)
+//	con, err := d.Dial("tcp", main)
 //	dnscon := &dns.Conn{Conn:con}
 //	transfer = &dns.Transfer{Conn: dnscon}
-//	channel, err := transfer.In(message, master)
+//	channel, err := transfer.In(message, main)
 //
 func (t *Transfer) In(q *Msg, a string) (env chan *Envelope, err error) {
 	timeout := dnsTimeout

--- a/src/tyk-gateway/api.go
+++ b/src/tyk-gateway/api.go
@@ -170,9 +170,9 @@ func doAddOrUpdate(keyName string, newSession *user.SessionState, dontReset bool
 		}
 	} else {
 		// nothing defined, add key to ALL
-		if !config.Global().AllowMasterKeys {
-			log.Error("Master keys disallowed in configuration, key not added.")
-			return errors.New("Master keys not allowed")
+		if !config.Global().AllowMainKeys {
+			log.Error("Main keys disallowed in configuration, key not added.")
+			return errors.New("Main keys not allowed")
 		}
 		log.Warning("No API Access Rights set, adding key to ALL.")
 		apisMu.RLock()
@@ -414,7 +414,7 @@ func handleAddKey(keyName, hashedName, sessionString, apiID string) {
 		"prefix": "RPC",
 		"key":    obfuscateKey(keyName),
 		"status": "ok",
-	}).Info("Updated hashed key in slave storage.")
+	}).Info("Updated hashed key in subordinate storage.")
 }
 
 func handleDeleteKey(keyName, apiID string) (interface{}, int) {
@@ -1015,7 +1015,7 @@ func createKeyHandler(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	} else {
-		if config.Global().AllowMasterKeys {
+		if config.Global().AllowMainKeys {
 			// nothing defined, add key to ALL
 			log.WithFields(logrus.Fields{
 				"prefix":      "api",
@@ -1047,14 +1047,14 @@ func createKeyHandler(w http.ResponseWriter, r *http.Request) {
 			log.WithFields(logrus.Fields{
 				"prefix":      "api",
 				"status":      "error",
-				"err":         "master keys disabled",
+				"err":         "main keys disabled",
 				"org_id":      newSession.OrgID,
 				"api_id":      "--",
 				"user_id":     "system",
 				"user_ip":     requestIPHops(r),
 				"path":        "--",
 				"server_name": "system",
-			}).Error("Master keys disallowed in configuration, key not added.")
+			}).Error("Main keys disallowed in configuration, key not added.")
 
 			doJSONWrite(w, http.StatusBadRequest, apiError("Failed to create key, keys must have at least one Access Rights record set."))
 			return

--- a/src/tyk-gateway/api_test.go
+++ b/src/tyk-gateway/api_test.go
@@ -139,8 +139,8 @@ func TestKeyHandler(t *testing.T) {
 	})
 
 	// Access right not specified
-	masterKey := createStandardSession()
-	masterKeyJSON, _ := json.Marshal(masterKey)
+	mainKey := createStandardSession()
+	mainKeyJSON, _ := json.Marshal(mainKey)
 
 	// with access
 	withAccess := createStandardSession()
@@ -177,8 +177,8 @@ func TestKeyHandler(t *testing.T) {
 
 	t.Run("Create key", func(t *testing.T) {
 		ts.Run(t, []test.TestCase{
-			// Master keys should be disabled by default
-			{Method: "POST", Path: "/tyk/keys/create", Data: string(masterKeyJSON), AdminAuth: true, Code: 400, BodyMatch: "Failed to create key, keys must have at least one Access Rights record set."},
+			// Main keys should be disabled by default
+			{Method: "POST", Path: "/tyk/keys/create", Data: string(mainKeyJSON), AdminAuth: true, Code: 400, BodyMatch: "Failed to create key, keys must have at least one Access Rights record set."},
 			{Method: "POST", Path: "/tyk/keys/create", Data: string(withAccessJSON), AdminAuth: true, Code: 200},
 		}...)
 	})

--- a/src/tyk-gateway/cli/lint/schema.go
+++ b/src/tyk-gateway/cli/lint/schema.go
@@ -54,7 +54,7 @@ const confSchema = `{
 	"allow_insecure_configs": {
 		"type": "boolean"
 	},
-	"allow_master_keys": {
+	"allow_main_keys": {
 		"type": "boolean"
 	},
 	"allow_remote_config": {
@@ -556,7 +556,7 @@ const confSchema = `{
 			}
 		}
 	},
-	"slave_options": {
+	"subordinate_options": {
 		"type": ["object", "null"],
 		"additionalProperties": false,
 		"properties": {

--- a/src/tyk-gateway/config/config.go
+++ b/src/tyk-gateway/config/config.go
@@ -97,7 +97,7 @@ type WebHookHandlerConf struct {
 	EventTimeout int64             `bson:"event_timeout" json:"event_timeout"`
 }
 
-type SlaveOptionsConfig struct {
+type SubordinateOptionsConfig struct {
 	UseRPC                          bool   `json:"use_rpc"`
 	UseSSL                          bool   `json:"use_ssl"`
 	SSLInsecureSkipVerify           bool   `json:"ssl_insecure_skip_verify"`
@@ -214,7 +214,7 @@ type Config struct {
 	UseAsyncSessionWrite              bool                                  `json:"optimisations_use_async_session_write"`
 	SessionUpdatePoolSize             int                                   `json:"session_update_pool_size"`
 	SessionUpdateBufferSize           int                                   `json:"session_update_buffer_size"`
-	AllowMasterKeys                   bool                                  `json:"allow_master_keys"`
+	AllowMainKeys                   bool                                  `json:"allow_main_keys"`
 	HashKeys                          bool                                  `json:"hash_keys"`
 	HashKeyFunction                   string                                `json:"hash_key_function"`
 	SuppressRedisSignalReload         bool                                  `json:"suppress_redis_signal_reload"`
@@ -245,7 +245,7 @@ type Config struct {
 	OauthTokenExpire                  int32                                 `json:"oauth_token_expire"`
 	OauthTokenExpiredRetainPeriod     int32                                 `json:"oauth_token_expired_retain_period"`
 	OauthRedirectUriSeparator         string                                `json:"oauth_redirect_uri_separator"`
-	SlaveOptions                      SlaveOptionsConfig                    `json:"slave_options"`
+	SubordinateOptions                      SubordinateOptionsConfig                    `json:"subordinate_options"`
 	DisableVirtualPathBlobs           bool                                  `json:"disable_virtual_path_blobs"`
 	LocalSessionCache                 LocalSessionCacheConf                 `json:"local_session_cache"`
 	HttpServerOptions                 HttpServerOptionsConfig               `json:"http_server_options"`

--- a/src/tyk-gateway/host_checker_manager.go
+++ b/src/tyk-gateway/host_checker_manager.go
@@ -108,7 +108,7 @@ func (hc *HostCheckerManager) CheckActivePollerLoop() {
 		} else {
 			log.WithFields(logrus.Fields{
 				"prefix": "host-check-mgr",
-			}).Debug("New master found, no tests running")
+			}).Debug("New main found, no tests running")
 			if hc.pollerStarted {
 				hc.StopPoller()
 				hc.pollerStarted = false
@@ -143,7 +143,7 @@ func (hc *HostCheckerManager) AmIPolling() bool {
 	if activeInstance == hc.Id {
 		log.WithFields(logrus.Fields{
 			"prefix": "host-check-mgr",
-		}).Debug("Primary instance set, I am master")
+		}).Debug("Primary instance set, I am main")
 		hc.store.SetKey(PollerCacheKey, hc.Id, 15) // Reset TTL
 		return true
 	}

--- a/src/tyk-gateway/redis_signal_handle_config.go
+++ b/src/tyk-gateway/redis_signal_handle_config.go
@@ -118,7 +118,7 @@ func sanitizeConfig(mc map[string]interface{}) map[string]interface{} {
 		"secret",
 		"node_secret",
 		"storage",
-		"slave_options",
+		"subordinate_options",
 		"auth_override",
 	}
 	for _, field_name := range sanitzeFields {

--- a/src/tyk-gateway/service_discovery_test.go
+++ b/src/tyk-gateway/service_discovery_test.go
@@ -152,7 +152,7 @@ const mesosphere = `{
 		"startedAt": "2016-03-15T14:37:55.941Z",
 		"stagedAt": "2016-03-15T14:37:52.792Z",
 		"version": "2016-03-15T14:37:52.726Z",
-		"slaveId": "d70867df-fdb2-4889-abeb-0829c742fded-S2",
+		"subordinateId": "d70867df-fdb2-4889-abeb-0829c742fded-S2",
 		"appId": "/httpbin"
 	}]
 }`


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.